### PR TITLE
add dev dependency on bresenham for example

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/madbence/node-drawille/issues"
+  },
+  "devDependencies": {
+    "bresenham": "0.0.1"
   }
 }


### PR DESCRIPTION
Adding the dependency to pacakge.json will make it easier for folks to checkout the app and quickly run the example.
