### PR TITLE
new Buffer() is deprecated, use Buffer.alloc() instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ Object.defineProperties(Canvas.prototype, {
     set: function (width) {
       width = Math.floor(width / 2) * 2;
       this._width = width;
-      this.content = new Buffer(this.width*this.height/8);
+      this.content = Buffer.alloc(this.width*this.height/8);
       this.content.fill(0);
     }
   },
@@ -36,7 +36,7 @@ Object.defineProperties(Canvas.prototype, {
     set: function (height) {
       height = Math.floor(height / 4) * 4;
       this._height = height;
-      this.content = new Buffer(this.width*this.height/8);
+      this.content = Buffer.alloc(this.width*this.height/8);
       this.content.fill(0);
     }
   }


### PR DESCRIPTION
I've been getting this:
> (node:3205) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

This little patch makes it go away